### PR TITLE
[[clang::always-destroy]] silences exit-time-destructor warnings

### DIFF
--- a/clang/lib/Sema/SemaDeclCXX.cpp
+++ b/clang/lib/Sema/SemaDeclCXX.cpp
@@ -16202,7 +16202,8 @@ void Sema::FinalizeVarWithDestructor(VarDecl *VD, const RecordType *Record) {
 
   // Emit warning for non-trivial dtor in global scope (a real global,
   // class-static, function-static).
-  Diag(VD->getLocation(), diag::warn_exit_time_destructor);
+  if (!VD->hasAttr<AlwaysDestroyAttr>())
+    Diag(VD->getLocation(), diag::warn_exit_time_destructor);
 
   // TODO: this should be re-enabled for static locals by !CXAAtExit
   if (!VD->isStaticLocal())

--- a/clang/test/SemaCXX/warn-exit-time-destructors.cpp
+++ b/clang/test/SemaCXX/warn-exit-time-destructors.cpp
@@ -51,6 +51,11 @@ struct A { ~A(); };
 }
 
 namespace test5 {
+struct A { ~A(); };
+[[clang::always_destroy]] A a; // no warning
+}
+
+namespace test6 {
 #if __cplusplus >= 202002L
 #define CPP20_CONSTEXPR constexpr
 #else
@@ -68,3 +73,4 @@ namespace test5 {
   T t; // expected-warning {{exit-time destructor}}
 #undef CPP20_CONSTEXPR
 }
+


### PR DESCRIPTION
user wants the warning silenced by the attribute
so no warning should be issued if the attribute is set.

including test
